### PR TITLE
Modernize to Jenkins 2.375.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <version>${revision}-${changelist}</version>
     <packaging>hpi</packaging>
     <properties>
-        <jenkins.version>2.361.1</jenkins.version>
+        <jenkins.version>2.375.4</jenkins.version>
         <revision>1.10.0</revision>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/commons-text-api-plugin</gitHubRepo>
@@ -25,6 +25,13 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-text</artifactId>
                 <version>${revision}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.375.x</artifactId>
+                <version>2198.v39c76fc308ca</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -42,7 +49,6 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>commons-lang3-api</artifactId>
-            <version>3.12.0-36.vd97de6465d5b_</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
This change raises the Jenkins baseline to 2.375.4 and introduces the plugins bom.

Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.jenkins.ModernizePlugin