### PR TITLE
Modernize to Jenkins 2.387.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,14 +4,14 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.72</version>
+        <version>4.73</version>
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>commons-text-api</artifactId>
     <version>${revision}-${changelist}</version>
     <packaging>hpi</packaging>
     <properties>
-        <jenkins.version>2.375.4</jenkins.version>
+        <jenkins.version>2.387.3</jenkins.version>
         <revision>1.10.0</revision>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/commons-text-api-plugin</gitHubRepo>
@@ -28,8 +28,8 @@
             </dependency>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.375.x</artifactId>
-                <version>2198.v39c76fc308ca</version>
+                <artifactId>bom-2.387.x</artifactId>
+                <version>2401.v7a_d68f8d0b_09</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Updates baseline Jenkins version to 2.387.3 and aligns the plugins bom.

Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.jenkins.ModernizePlugin

Closes #44