### PR TITLE
Modernize to Jenkins 2.401.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,8 @@
             </dependency>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.387.x</artifactId>
-                <version>2543.vfb_1a_5fb_9496d</version>
+                <artifactId>bom-2.401.x</artifactId>
+                <version>2612.v3d6a_2128c0ef</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <version>${revision}-${changelist}</version>
     <packaging>hpi</packaging>
     <properties>
-        <jenkins.version>2.387.3</jenkins.version>
+        <jenkins.version>2.401.3</jenkins.version>
         <revision>1.11.0</revision>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/commons-text-api-plugin</gitHubRepo>


### PR DESCRIPTION
Hi!

This PR aims to modernize tooling and move this plugin to the [recommended](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/) Jenkins baseline version.

2.401.2 was the [first version to include Guice 6.x](https://www.jenkins.io/changelog-stable/#v2.401.2), which supports `jakarta.inject`.

## Testing done
Ran `mvn clean verify`.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

Refs: sghill-rewrite/campaigns#1

Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.jenkins.ModernizePlugin