### PR TITLE
Adapt build status icon for ci.jenkins.io permissions change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 commons-text-api Plugin
 ===================
 
-[![Build Status](https://ci.jenkins.io/job/Plugins/job/commons-text-api-plugin/job/main/badge/icon)](https://ci.jenkins.io/job/Plugins/job/commons-text-api-plugin/job/main/)
+[![Build Status](https://ci.jenkins.io/buildStatus/icon?job=Plugins%2Fcommons-text-api-plugin%2Fmain)](https://ci.jenkins.io/job/Plugins/job/commons-text-api-plugin/job/main/)
 [![Contributors](https://img.shields.io/github/contributors/jenkinsci/commons-text-api-plugin.svg)](https://github.com/jenkinsci/commons-text-api-plugin/graphs/contributors)
 [![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/commons-text-api.svg)](https://plugins.jenkins.io/commons-text-api)
 [![GitHub release](https://img.shields.io/github/v/tag/jenkinsci/commons-text-api-plugin?label=changelog)](https://github.com/jenkinsci/commons-text-api-plugin/blob/main/CHANGELOG.md)


### PR DESCRIPTION
## Adapt build status icon for ci.jenkins.io permissions change

Large language models and other readers were causing performance problems.  The ci.jenkins.io controller has been reconfigured to limit access to authenticated users in order to prevent performance problems.  That change requires that we adjust the URL of the embeddable build status update URL.

### Testing done

* Validated the change in a sample repository
* Will check the pull request after it is submitted

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
